### PR TITLE
16-bit (ushort) diagonal calculation

### DIFF
--- a/src/Quickenshtein/Levenshtein.Intrinsics.cs
+++ b/src/Quickenshtein/Levenshtein.Intrinsics.cs
@@ -9,6 +9,8 @@ namespace Quickenshtein
 	public static partial class Levenshtein
 	{
 		private static readonly Vector256<int> ROTL1_256 = Vector256.Create(7, 0, 1, 2, 3, 4, 5, 6);
+		private static readonly Vector128<byte> REVERSE_USHORT_AS_BYTE_128 = Vector128.Create((byte)14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
+		private static readonly Vector256<byte> REVERSE_USHORT_AS_BYTE_256 = Vector256.Create((byte)30, 31, 28, 29, 26, 27, 24, 25, 22, 23, 20, 21, 18, 19, 16, 17, 14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1);
 
 		/// <summary>
 		/// Using SSE4.1, calculates the costs for an entire row of the virtual matrix.
@@ -112,81 +114,160 @@ namespace Quickenshtein
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static unsafe void CalculateDiagonal_MinSse41(int* diag1Ptr, int* diag2Ptr, char* sourcePtr, char* targetPtr, int targetLength, ref int rowIndex, int columnIndex)
+		private static unsafe void CalculateDiagonalSection_MinSse41<T>(IntPtr managedDiag1Ptr, IntPtr managedDiag2Ptr, char* sourcePtr, char* targetPtr, int targetLength, ref int rowIndex, int columnIndex) where T : struct
 		{
-			if (Avx2.IsSupported && rowIndex >= Vector256<int>.Count && targetLength - columnIndex >= Vector256<int>.Count)
+			if (Avx2.IsSupported && rowIndex >= Vector256<T>.Count && targetLength - columnIndex >= Vector256<T>.Count)
 			{
-				CalculateDiagonal_Eight_Avx2(diag1Ptr, diag2Ptr, sourcePtr, targetPtr, ref rowIndex, columnIndex);
-				rowIndex -= Vector256<int>.Count;
+				CalculateDiagonalSection_Avx2<T>(managedDiag1Ptr, managedDiag2Ptr, sourcePtr, targetPtr, ref rowIndex, columnIndex);
+				rowIndex -= Vector256<T>.Count;
 			}
-			else if (rowIndex >= Vector128<int>.Count && targetLength - columnIndex >= Vector128<int>.Count)
+			else if (rowIndex >= Vector128<T>.Count && targetLength - columnIndex >= Vector128<T>.Count)
 			{
-				CalculateDiagonal_Four_Sse41(diag1Ptr, diag2Ptr, sourcePtr, targetPtr, ref rowIndex, columnIndex);
-				rowIndex -= Vector128<int>.Count;
+				CalculateDiagonalSection_Sse41<T>(managedDiag1Ptr, managedDiag2Ptr, sourcePtr, targetPtr, ref rowIndex, columnIndex);
+				rowIndex -= Vector128<T>.Count;
 			}
 			else
 			{
-				CalculateDiagonal_One(diag1Ptr, diag2Ptr, sourcePtr, targetPtr, ref rowIndex, columnIndex);
+				CalculateDiagonalSection_Single<T>(managedDiag1Ptr, managedDiag2Ptr, sourcePtr, targetPtr, ref rowIndex, columnIndex);
 				rowIndex--;
 			}
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static unsafe void CalculateDiagonal_One(int* diag1Ptr, int* diag2Ptr, char* sourcePtr, char* targetPtr, ref int rowIndex, int columnIndex)
+		private static unsafe void CalculateDiagonalSection_Single<T>(IntPtr managedDiag1Ptr, IntPtr managedDiag2Ptr, char* sourcePtr, char* targetPtr, ref int rowIndex, int columnIndex) where T : struct
 		{
-			var localCost = Math.Min(diag2Ptr[rowIndex], diag2Ptr[rowIndex - 1]);
-			if (localCost < diag1Ptr[rowIndex - 1])
+			if (typeof(T) == typeof(int))
 			{
-				diag1Ptr[rowIndex] = localCost + 1;
+				var diag1Ptr = (int*)managedDiag1Ptr;
+				var diag2Ptr = (int*)managedDiag2Ptr;
+
+				var localCost = Math.Min(diag2Ptr[rowIndex], diag2Ptr[rowIndex - 1]);
+				if (localCost < diag1Ptr[rowIndex - 1])
+				{
+					diag1Ptr[rowIndex] = localCost + 1;
+				}
+				else
+				{
+					diag1Ptr[rowIndex] = diag1Ptr[rowIndex - 1] + (sourcePtr[rowIndex - 1] != targetPtr[columnIndex - 1] ? 1 : 0);
+				}
 			}
-			else
+			else if (typeof(T) == typeof(ushort))
 			{
-				diag1Ptr[rowIndex] = diag1Ptr[rowIndex - 1] + (sourcePtr[rowIndex - 1] != targetPtr[columnIndex - 1] ? 1 : 0);
+				var diag1Ptr = (ushort*)managedDiag1Ptr;
+				var diag2Ptr = (ushort*)managedDiag2Ptr;
+
+				var localCost = Math.Min(diag2Ptr[rowIndex], diag2Ptr[rowIndex - 1]);
+				if (localCost < diag1Ptr[rowIndex - 1])
+				{
+					diag1Ptr[rowIndex] = (ushort)(localCost + 1);
+				}
+				else
+				{
+					diag1Ptr[rowIndex] = (ushort)(diag1Ptr[rowIndex - 1] + (sourcePtr[rowIndex - 1] != targetPtr[columnIndex - 1] ? 1 : 0));
+				}
 			}
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static unsafe void CalculateDiagonal_Four_Sse41(int* diag1Ptr, int* diag2Ptr, char* sourcePtr, char* targetPtr, ref int rowIndex, int columnIndex)
+		private static unsafe void CalculateDiagonalSection_Sse41<T>(IntPtr managedDiag1Ptr, IntPtr managedDiag2Ptr, char* sourcePtr, char* targetPtr, ref int rowIndex, int columnIndex) where T : struct
 		{
-			var sourceVector = Sse41.ConvertToVector128Int32((ushort*)sourcePtr + rowIndex - 4);
-			var targetVector = Sse41.ConvertToVector128Int32((ushort*)targetPtr + columnIndex - 1);
-			targetVector = Sse2.Shuffle(targetVector, 0x1b);
-			var substitutionCostAdjustment = Sse2.CompareEqual(sourceVector, targetVector);
+			if (typeof(T) == typeof(int))
+			{
+				var diag1Ptr = (int*)managedDiag1Ptr;
+				var diag2Ptr = (int*)managedDiag2Ptr;
 
-			var substitutionCost = Sse2.Add(
-				Sse3.LoadDquVector128(diag1Ptr + rowIndex - 4),
-				substitutionCostAdjustment
-			);
+				var sourceVector = Sse41.ConvertToVector128Int32((ushort*)sourcePtr + rowIndex - Vector128<T>.Count);
+				var targetVector = Sse41.ConvertToVector128Int32((ushort*)targetPtr + columnIndex - 1);
+				targetVector = Sse2.Shuffle(targetVector, 0x1b);
+				var substitutionCostAdjustment = Sse2.CompareEqual(sourceVector, targetVector);
 
-			var deleteCost = Sse3.LoadDquVector128(diag2Ptr + rowIndex - 3);
-			var insertCost = Sse3.LoadDquVector128(diag2Ptr + rowIndex - 4);
+				var substitutionCost = Sse2.Add(
+					Sse3.LoadDquVector128(diag1Ptr + rowIndex - Vector128<T>.Count),
+					substitutionCostAdjustment
+				);
 
-			var localCost = Sse41.Min(Sse41.Min(insertCost, deleteCost), substitutionCost);
-			localCost = Sse2.Add(localCost, Vector128.Create(1));
+				var deleteCost = Sse3.LoadDquVector128(diag2Ptr + rowIndex - (Vector128<T>.Count - 1));
+				var insertCost = Sse3.LoadDquVector128(diag2Ptr + rowIndex - Vector128<T>.Count);
 
-			Sse2.Store(diag1Ptr + rowIndex - 3, localCost);
+				var localCost = Sse41.Min(Sse41.Min(insertCost, deleteCost), substitutionCost);
+				localCost = Sse2.Add(localCost, Vector128.Create(1));
+
+				Sse2.Store(diag1Ptr + rowIndex - (Vector128<T>.Count - 1), localCost);
+			}
+			else if (typeof(T) == typeof(ushort))
+			{
+				var diag1Ptr = (ushort*)managedDiag1Ptr;
+				var diag2Ptr = (ushort*)managedDiag2Ptr;
+
+				var sourceVector = Sse3.LoadDquVector128((ushort*)sourcePtr + rowIndex - Vector128<T>.Count);
+				var targetVector = Sse3.LoadDquVector128((ushort*)targetPtr + columnIndex - 1);
+				targetVector = Ssse3.Shuffle(targetVector.AsByte(), REVERSE_USHORT_AS_BYTE_128).AsUInt16();
+				var substitutionCostAdjustment = Sse2.CompareEqual(sourceVector, targetVector);
+
+				var substitutionCost = Sse2.Add(
+					Sse3.LoadDquVector128(diag1Ptr + rowIndex - Vector128<T>.Count),
+					substitutionCostAdjustment
+				);
+
+				var deleteCost = Sse3.LoadDquVector128(diag2Ptr + rowIndex - (Vector128<T>.Count - 1));
+				var insertCost = Sse3.LoadDquVector128(diag2Ptr + rowIndex - Vector128<T>.Count);
+
+				var localCost = Sse41.Min(Sse41.Min(insertCost, deleteCost), substitutionCost);
+				localCost = Sse2.Add(localCost, Vector128.Create((ushort)1));
+
+				Sse2.Store(diag1Ptr + rowIndex - (Vector128<T>.Count - 1), localCost);
+			}
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		private static unsafe void CalculateDiagonal_Eight_Avx2(int* diag1Ptr, int* diag2Ptr, char* sourcePtr, char* targetPtr, ref int rowIndex, int columnIndex)
+		private static unsafe void CalculateDiagonalSection_Avx2<T>(IntPtr managedDiag1Ptr, IntPtr managedDiag2Ptr, char* sourcePtr, char* targetPtr, ref int rowIndex, int columnIndex) where T : struct
 		{
-			var sourceVector = Avx2.ConvertToVector256Int32((ushort*)sourcePtr + rowIndex - 8);
-			var targetVector = Avx2.ConvertToVector256Int32((ushort*)targetPtr + columnIndex - 1);
-			targetVector = Avx2.Shuffle(targetVector, 0x1b);
-			targetVector = Avx2.Permute2x128(targetVector, targetVector, 1);
-			var substitutionCostAdjustment = Avx2.CompareEqual(sourceVector, targetVector);
+			if (typeof(T) == typeof(int))
+			{
+				var diag1Ptr = (int*)managedDiag1Ptr;
+				var diag2Ptr = (int*)managedDiag2Ptr;
 
-			var substitutionCost = Avx2.Add(
-				Avx.LoadDquVector256(diag1Ptr + rowIndex - 8),
-				substitutionCostAdjustment
-			);
-			var deleteCost = Avx.LoadDquVector256(diag2Ptr + rowIndex - 7);
-			var insertCost = Avx.LoadDquVector256(diag2Ptr + rowIndex - 8);
+				var sourceVector = Avx2.ConvertToVector256Int32((ushort*)sourcePtr + rowIndex - Vector256<T>.Count);
+				var targetVector = Avx2.ConvertToVector256Int32((ushort*)targetPtr + columnIndex - 1);
+				targetVector = Avx2.Shuffle(targetVector, 0x1b);
+				targetVector = Avx2.Permute2x128(targetVector, targetVector, 1);
+				var substitutionCostAdjustment = Avx2.CompareEqual(sourceVector, targetVector);
 
-			var localCost = Avx2.Min(Avx2.Min(insertCost, deleteCost), substitutionCost);
-			localCost = Avx2.Add(localCost, Vector256.Create(1));
+				var substitutionCost = Avx2.Add(
+					Avx.LoadDquVector256(diag1Ptr + rowIndex - Vector256<T>.Count),
+					substitutionCostAdjustment
+				);
+				var deleteCost = Avx.LoadDquVector256(diag2Ptr + rowIndex - (Vector256<T>.Count - 1));
+				var insertCost = Avx.LoadDquVector256(diag2Ptr + rowIndex - Vector256<T>.Count);
 
-			Avx.Store(diag1Ptr + rowIndex - 7, localCost);
+				var localCost = Avx2.Min(Avx2.Min(insertCost, deleteCost), substitutionCost);
+				localCost = Avx2.Add(localCost, Vector256.Create(1));
+
+				Avx.Store(diag1Ptr + rowIndex - (Vector256<T>.Count - 1), localCost);
+			}
+			else if (typeof(T) == typeof(ushort))
+			{
+				var diag1Ptr = (ushort*)managedDiag1Ptr;
+				var diag2Ptr = (ushort*)managedDiag2Ptr;
+
+				var sourceVector = Avx.LoadDquVector256((ushort*)sourcePtr + rowIndex - Vector256<T>.Count);
+				var targetVector = Avx.LoadDquVector256((ushort*)targetPtr + columnIndex - 1);
+				targetVector = Avx2.Shuffle(targetVector.AsByte(), REVERSE_USHORT_AS_BYTE_256).AsUInt16();
+				targetVector = Avx2.Permute2x128(targetVector, targetVector, 1);
+				var substitutionCostAdjustment = Avx2.CompareEqual(sourceVector, targetVector);
+
+				var substitutionCost = Avx2.Add(
+					Avx.LoadDquVector256(diag1Ptr + rowIndex - Vector256<T>.Count),
+					substitutionCostAdjustment
+				);
+				var deleteCost = Avx.LoadDquVector256(diag2Ptr + rowIndex - (Vector256<T>.Count - 1));
+				var insertCost = Avx.LoadDquVector256(diag2Ptr + rowIndex - Vector256<T>.Count);
+
+				var localCost = Avx2.Min(Avx2.Min(insertCost, deleteCost), substitutionCost);
+				localCost = Avx2.Add(localCost, Vector256.Create((ushort)1));
+
+				Avx.Store(diag1Ptr + rowIndex - (Vector256<T>.Count - 1), localCost);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds support for a ushort fast-path in the diagonal calculation, allowing up to 16x items to be processed at once.

Its approximately 15% faster for strings smaller than `ushort.MaxValue` in a 8000 character benchmark.

**Int32**
|        Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| Quickenshtein | 26.68 ms | 0.213 ms | 0.189 ms |     - |     - |     - |         - |

**ushort**
|        Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| Quickenshtein | 23.15 ms | 0.112 ms | 0.105 ms |     - |     - |     - |         - |

Unfortunately tests and test coverage become a complicated mess...