### PR TITLE
Added branchless Math.Min calculation

### DIFF
--- a/src/Quickenshtein/Internal/AdvOperations.cs
+++ b/src/Quickenshtein/Internal/AdvOperations.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Quickenshtein.Internal
+{
+	internal static class AdvOperations
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static int MathMin(int x, int y)
+		{
+			return y + ((x - y) & ((x - y) >> (sizeof(int) * 8 - 1)));
+		}
+	}
+}

--- a/src/Quickenshtein/Levenshtein.Common.cs
+++ b/src/Quickenshtein/Levenshtein.Common.cs
@@ -35,8 +35,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -49,8 +49,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -63,8 +63,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -77,8 +77,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -91,8 +91,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -105,8 +105,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -119,8 +119,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -133,8 +133,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -152,8 +152,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -166,8 +166,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -180,8 +180,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -194,8 +194,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -213,8 +213,8 @@ namespace Quickenshtein
 				lastDeletionCost = previousRowPtr[0];
 				if (sourcePrevChar != targetPtr[0])
 				{
-					localCost = Math.Min(lastInsertionCost, localCost);
-					localCost = Math.Min(lastDeletionCost, localCost);
+					localCost = AdvOperations.MathMin(lastInsertionCost, localCost);
+					localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 					localCost++;
 				}
 				lastInsertionCost = localCost;
@@ -307,8 +307,8 @@ namespace Quickenshtein
 			var localCost = row1Costs;
 			if (sourceChar1 != targetChar)
 			{
-				localCost = Math.Min(row2Costs, localCost);
-				localCost = Math.Min(lastDeletionCost, localCost);
+				localCost = AdvOperations.MathMin(row2Costs, localCost);
+				localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 				localCost++;
 			}
 			row1Costs = lastDeletionCost;
@@ -316,8 +316,8 @@ namespace Quickenshtein
 			localCost = row2Costs;
 			if (sourceChar2 != targetChar)
 			{
-				localCost = Math.Min(row3Costs, localCost);
-				localCost = Math.Min(lastDeletionCost, localCost);
+				localCost = AdvOperations.MathMin(row3Costs, localCost);
+				localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 				localCost++;
 			}
 			row2Costs = lastDeletionCost;
@@ -325,8 +325,8 @@ namespace Quickenshtein
 			localCost = row3Costs;
 			if (sourceChar3 != targetChar)
 			{
-				localCost = Math.Min(row4Costs, localCost);
-				localCost = Math.Min(lastDeletionCost, localCost);
+				localCost = AdvOperations.MathMin(row4Costs, localCost);
+				localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 				localCost++;
 			}
 			row3Costs = lastDeletionCost;
@@ -334,8 +334,8 @@ namespace Quickenshtein
 			localCost = row4Costs;
 			if (sourceChar4 != targetChar)
 			{
-				localCost = Math.Min(row5Costs, localCost);
-				localCost = Math.Min(lastDeletionCost, localCost);
+				localCost = AdvOperations.MathMin(row5Costs, localCost);
+				localCost = AdvOperations.MathMin(lastDeletionCost, localCost);
 				localCost++;
 			}
 			row4Costs = lastDeletionCost;


### PR DESCRIPTION
Based on this tweet: https://mobile.twitter.com/badamczewski01/status/1273759277707132928

**Results**
```
|                 Method |       Runtime | NumberOfCharacters |               Mean |               Error |             StdDev | Ratio | Speedup | Worthiness | RatioSD | Code Size |      Gen 0 |      Gen 1 |     Gen 2 |   Allocated |
|----------------------- |-------------- |------------------- |-------------------:|--------------------:|-------------------:|------:|--------:|-----------:|--------:|----------:|-----------:|-----------:|----------:|------------:|
|               Baseline |    .NET 4.7.2 |                  0 |         220.189 ns |          24.1378 ns |          1.3231 ns | 1.000 |    1.00 |       1.00 |    0.00 |    2557 B |     0.1018 |          - |         - |       321 B |
|          Quickenshtein |    .NET 4.7.2 |                  0 |           2.583 ns |           0.1834 ns |          0.0101 ns | 0.012 |   85.24 |   1,095.27 |    0.00 |     199 B |          - |          - |         - |           - |
| Quickenshtein_Threaded |    .NET 4.7.2 |                  0 |           1.790 ns |           0.5424 ns |          0.0297 ns | 0.008 |  123.05 |   1,757.70 |    0.00 |     179 B |          - |          - |         - |           - |
|           Fastenshtein |    .NET 4.7.2 |                  0 |           2.489 ns |           1.4295 ns |          0.0784 ns | 0.011 |   88.51 |     689.97 |    0.00 |     328 B |          - |          - |         - |           - |
|               Baseline | .NET Core 3.0 |                  0 |         112.910 ns |           4.6300 ns |          0.2538 ns | 0.513 |    1.95 |       2.57 |    0.00 |    1938 B |     0.0764 |          - |         - |       240 B |
|          Quickenshtein | .NET Core 3.0 |                  0 |           4.067 ns |           0.1389 ns |          0.0076 ns | 0.018 |   54.14 |     538.69 |    0.00 |     257 B |          - |          - |         - |           - |
| Quickenshtein_Threaded | .NET Core 3.0 |                  0 |           2.127 ns |           0.7267 ns |          0.0398 ns | 0.010 |  103.53 |   1,423.33 |    0.00 |     186 B |          - |          - |         - |           - |
|           Fastenshtein | .NET Core 3.0 |                  0 |           2.396 ns |           0.6282 ns |          0.0344 ns | 0.011 |   91.92 |     714.39 |    0.00 |     329 B |          - |          - |         - |           - |
|                        |               |                    |                    |                     |                    |       |         |            |         |           |            |            |           |             |
|               Baseline |    .NET 4.7.2 |                 10 |       1,252.135 ns |         120.7927 ns |          6.6211 ns |  1.00 |    1.00 |       1.00 |    0.00 |    2557 B |     0.4463 |          - |         - |      1404 B |
|          Quickenshtein |    .NET 4.7.2 |                 10 |         260.836 ns |          16.0352 ns |          0.8789 ns |  0.21 |    4.80 |       2.23 |    0.00 |    5501 B |          - |          - |         - |           - |
| Quickenshtein_Threaded |    .NET 4.7.2 |                 10 |         262.059 ns |          14.9552 ns |          0.8197 ns |  0.21 |    4.78 |       2.08 |    0.00 |    5878 B |          - |          - |         - |           - |
|           Fastenshtein |    .NET 4.7.2 |                 10 |         258.354 ns |          38.7140 ns |          2.1220 ns |  0.21 |    4.85 |      37.79 |    0.00 |     328 B |     0.0200 |          - |         - |        64 B |
|               Baseline | .NET Core 3.0 |                 10 |         749.766 ns |          34.1184 ns |          1.8701 ns |  0.60 |    1.67 |       2.20 |    0.00 |    1938 B |     0.3443 |          - |         - |      1080 B |
|          Quickenshtein | .NET Core 3.0 |                 10 |         369.429 ns |          22.4171 ns |          1.2288 ns |  0.30 |    3.39 |       1.91 |    0.00 |    4536 B |          - |          - |         - |           - |
| Quickenshtein_Threaded | .NET Core 3.0 |                 10 |         352.946 ns |          12.0771 ns |          0.6620 ns |  0.28 |    3.55 |       1.70 |    0.00 |    5335 B |          - |          - |         - |           - |
|           Fastenshtein | .NET Core 3.0 |                 10 |         237.126 ns |          23.6289 ns |          1.2952 ns |  0.19 |    5.28 |      41.04 |    0.00 |     329 B |     0.0200 |          - |         - |        64 B |
|                        |               |                    |                    |                     |                    |       |         |            |         |           |            |            |           |             |
|               Baseline |    .NET 4.7.2 |                400 |     889,130.599 ns |      66,393.8252 ns |      3,639.2696 ns |  1.00 |    1.00 |       1.00 |    0.00 |    2557 B |   142.5781 |    59.5703 |         - |    668278 B |
|          Quickenshtein |    .NET 4.7.2 |                400 |     250,343.913 ns |      21,465.3674 ns |      1,176.5892 ns |  0.28 |    3.55 |       1.65 |    0.00 |    5501 B |          - |          - |         - |           - |
| Quickenshtein_Threaded |    .NET 4.7.2 |                400 |     250,369.938 ns |       8,883.9636 ns |        486.9600 ns |  0.28 |    3.55 |       1.54 |    0.00 |    5878 B |          - |          - |         - |           - |
|           Fastenshtein |    .NET 4.7.2 |                400 |     438,383.122 ns |      39,211.2402 ns |      2,149.3004 ns |  0.49 |    2.03 |      15.81 |    0.00 |     328 B |     0.4883 |          - |         - |      1633 B |
|               Baseline | .NET Core 3.0 |                400 |     865,893.945 ns |      72,297.3258 ns |      3,962.8604 ns |  0.97 |    1.03 |       1.35 |    0.00 |    1938 B |   121.0938 |    60.5469 |         - |    657840 B |
|          Quickenshtein | .NET Core 3.0 |                400 |      78,144.973 ns |       6,586.3546 ns |        361.0203 ns |  0.09 |   11.38 |       6.41 |    0.00 |    4536 B |          - |          - |         - |           - |
| Quickenshtein_Threaded | .NET Core 3.0 |                400 |      78,146.643 ns |      11,238.2866 ns |        616.0084 ns |  0.09 |   11.38 |       5.06 |    0.00 |    5754 B |          - |          - |         - |           - |
|           Fastenshtein | .NET Core 3.0 |                400 |     357,707.454 ns |      18,138.3426 ns |        994.2238 ns |  0.40 |    2.49 |      19.32 |    0.00 |     329 B |     0.4883 |          - |         - |      1624 B |
|                        |               |                    |                    |                     |                    |       |         |            |         |           |            |            |           |             |
|               Baseline |    .NET 4.7.2 |               8000 | 393,884,266.667 ns |  49,006,820.6381 ns |  2,686,229.2053 ns |  1.00 |    1.00 |       1.00 |    0.00 |    2557 B | 44000.0000 | 23000.0000 | 4000.0000 | 256683568 B |
|          Quickenshtein |    .NET 4.7.2 |               8000 | 100,370,120.000 ns |  13,370,648.7190 ns |    732,890.3735 ns |  0.25 |    3.92 |       1.82 |    0.00 |    5501 B |          - |          - |         - |           - |
| Quickenshtein_Threaded |    .NET 4.7.2 |               8000 |  26,717,654.167 ns |  36,141,920.5933 ns |  1,981,060.6232 ns |  0.07 |   14.80 |       6.83 |    0.01 |    5538 B |          - |          - |         - |      1024 B |
|           Fastenshtein |    .NET 4.7.2 |               8000 | 159,648,433.333 ns |  28,111,703.1594 ns |  1,540,897.3089 ns |  0.41 |    2.47 |      19.23 |    0.00 |     328 B |          - |          - |         - |     32048 B |
|               Baseline | .NET Core 3.0 |               8000 | 433,869,533.333 ns | 248,847,936.6442 ns | 13,640,195.1072 ns |  1.10 |    0.91 |       1.28 |    0.04 |    1812 B | 44000.0000 | 23000.0000 | 4000.0000 | 256352240 B |
|          Quickenshtein | .NET Core 3.0 |               8000 |  24,698,026.042 ns |   2,775,654.4912 ns |    152,142.9887 ns |  0.06 |   15.95 |       8.99 |    0.00 |    4536 B |          - |          - |         - |        14 B |
| Quickenshtein_Threaded | .NET Core 3.0 |               8000 |  24,912,576.042 ns |   2,509,390.7247 ns |    137,548.1732 ns |  0.06 |   15.81 |       7.05 |    0.00 |    5731 B |          - |          - |         - |           - |
|           Fastenshtein | .NET Core 3.0 |               8000 | 137,326,183.333 ns |  18,542,076.7650 ns |  1,016,353.7949 ns |  0.35 |    2.87 |      22.29 |    0.00 |     329 B |          - |          - |         - |     32024 B |
```