### PR TITLE
Always include the string method into the output

### DIFF
--- a/src/Quickenshtein/Levenshtein.cs
+++ b/src/Quickenshtein/Levenshtein.cs
@@ -18,24 +18,9 @@ namespace Quickenshtein
 			return GetDistance(source, target, CalculationOptions.Default);
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static unsafe int GetDistance(string source, string target, CalculationOptions calculationOptions)
+		public static int GetDistance(string source, string target, CalculationOptions calculationOptions)
 		{
-			//Shortcut any processing if either string is empty
-			if (source == null || source.Length == 0)
-			{
-				return target?.Length ?? 0;
-			}
-			if (target == null || target.Length == 0)
-			{
-				return source.Length;
-			}
-
-			fixed (char* sourcePtr = source)
-			fixed (char* targetPtr = target)
-			{
-				return CalculateDistance(sourcePtr, targetPtr, source.Length, target.Length, calculationOptions);
-			}
+			return GetDistance(source.AsSpan(), target.AsSpan(), calculationOptions);
 		}
 
 		public static unsafe int GetDistance(ReadOnlySpan<char> source, ReadOnlySpan<char> target)

--- a/src/Quickenshtein/Levenshtein.cs
+++ b/src/Quickenshtein/Levenshtein.cs
@@ -13,7 +13,6 @@ namespace Quickenshtein
 	/// </summary>
 	public static partial class Levenshtein
 	{
-#if NETSTANDARD
 		public static int GetDistance(string source, string target)
 		{
 			return GetDistance(source, target, CalculationOptions.Default);
@@ -38,7 +37,6 @@ namespace Quickenshtein
 				return CalculateDistance(sourcePtr, targetPtr, source.Length, target.Length, calculationOptions);
 			}
 		}
-#endif
 
 		public static unsafe int GetDistance(ReadOnlySpan<char> source, ReadOnlySpan<char> target)
 		{


### PR DESCRIPTION
As discussed in: https://github.com/Turnerj/Quickenshtein/issues/45

As far as I can see, there is no reason to remove this method when targeting non-netstandard outputs (net/netcore etc).